### PR TITLE
Enable Juvia as an alternative to Disqus comments.

### DIFF
--- a/source/_includes/juvia.html
+++ b/source/_includes/juvia.html
@@ -1,0 +1,51 @@
+{% comment %} Load script if Juvia comments are enabled and `page.comments` is either empty (index) or set to true {% endcomment %}
+{% if site.juvia_site_key and site.juvia_host and page.comments != false %}
+<script type="text/javascript" class="juvia">
+(function() {
+    var options = {
+        container   : '#juvia_thread',
+        site_key    : '{{ site.juvia_site_key }}',
+        topic_key   : location.pathname,
+        topic_url   : location.href,
+        topic_title : document.title || location.href,
+        include_base: !window.Juvia,
+        include_css : !window.Juvia
+    };
+
+    function makeQueryString(options) {
+        var key, params = [];
+        for (key in options) {
+            params.push(
+                encodeURIComponent(key) +
+                '=' +
+                encodeURIComponent(options[key]));
+        }
+        return params.join('&');
+    }
+
+    function makeApiUrl(options) {
+        // Makes sure that each call generates a unique URL, otherwise
+        // the browser may not actually perform the request.
+        if (!('_juviaRequestCounter' in window)) {
+            window._juviaRequestCounter = 0;
+        }
+
+        var result =
+            'http://{{ site.juvia_host }}/api/show_topic.js' +
+            '?_c=' + window._juviaRequestCounter +
+            '&' + makeQueryString(options);
+        window._juviaRequestCounter++;
+        return result;
+    }
+
+    var s       = document.createElement('script');
+    s.async     = true;
+    s.type      = 'text/javascript';
+    s.className = 'juvia';
+    s.src       = makeApiUrl(options);
+    (document.getElementsByTagName('head')[0] ||
+     document.getElementsByTagName('body')[0]).appendChild(s);
+})();
+</script>
+
+{% endif %}

--- a/source/_includes/post/juvia_thread.html
+++ b/source/_includes/post/juvia_thread.html
@@ -1,0 +1,1 @@
+<noscript>Please enable JavaScript to view the comments powered by Juvia.</noscript>

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -30,6 +30,12 @@ layout: default
     <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
   </section>
 {% endif %}
+{% if site.juvia_site_key and page.comments == true %}
+  <section>
+    <h1>Comments</h1>
+    <div id="juvia_thread" aria-live="polite">{% include post/juvia_thread.html %}</div>
+  </section>
+{% endif %}
 </div>
 {% unless page.sidebar == false %}
 <aside class="sidebar">

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -31,6 +31,12 @@ single: true
     <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
   </section>
 {% endif %}
+{% if site.juvia_site_key and page.comments == true %}
+  <section>
+    <h1>Comments</h1>
+    <div id="juvia_thread" aria-live="polite">{% include post/juvia_thread.html %}</div>
+  </section>
+{% endif %}
 </div>
 {% unless page.sidebar == false %}
 <aside class="sidebar">


### PR DESCRIPTION
This patch adds support for the open-source Juvia comment system (https://github.com/phusion/juvia) as an alternative to Disqus.

It requires two extra parameters in _config.yml: `juvia_site_key` and `juvia_host`. I added a pull request on Octopress which adds Juvia support to the original theme (and the _config.yml parameters too): https://github.com/imathis/octopress/pull/1224  Since I use whitespace on my own site, I've added support to this theme too.
