### PR TITLE
Justified text in the main container.

### DIFF
--- a/sass/base/_layout.scss
+++ b/sass/base/_layout.scss
@@ -144,6 +144,7 @@ body.sidebar-footer {
     .no-sidebar & { margin-right: 0; border-right: 0; }
     .collapse-sidebar & { margin-right: 20px; }
     > div, > article {
+      text-align:justify;
       padding-top: $pad-medium/2;
       padding-bottom: $pad-medium/2;
       float: left;


### PR DESCRIPTION
I believe the text looks a lot better when justified to the container - especially as the whitespace theme design does not have delimiting elements for the article content.

Also, I'm wondering if `float: left` is really a good way to position the article container. Why not:

``` css
display: block;
margin-left: auto;
margin-right: auto;
```

?
