### PR TITLE
Improved footer

### DIFF
--- a/sass/partials/_footer.scss
+++ b/sass/partials/_footer.scss
@@ -1,5 +1,6 @@
 body > footer {
   @extend .sans;
+  text-align: center;
   font-size: .8em;
   color: $footer-color;
   text-shadow: lighten($footer-bg, 5) 0 1px;

--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -1,4 +1,4 @@
 <p>
   Copyright &copy; {{ site.time | date: "%Y" }} - {{ site.author }} -
-  <span class="credit">Powered by <a href="http://octopress.org">Octopress</a></span>
+  <span class="credit">Powered by <a href="http://octopress.org">Octopress</a> | Themed with <a href="https://github.com/lucaslew/whitespace">whitespace</a></span>
 </p>


### PR DESCRIPTION
The footer was left-aligned, which looked a bit weird for shorter texts. Switched that to center -align. Also added a credit notice and link for the theme (whitespace ^^).
