### PR TITLE
Remove italic style from blockquote

### DIFF
--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -112,7 +112,6 @@ big { font-size: 1.2em; }
 
 article blockquote {
   $bq-margin: 1.2em;
-  font-style: italic;
   position: relative;
   font-size: 1.2em;
   line-height: 1.5em;


### PR DESCRIPTION
Italic blockquotes are hard to read and also we're not sure how it looks with international characters. Although we remove this style now, users can apply italic style to the blockquote. They can select a specific _part_!

FYI, I didn't remove style from `cite`, but if you want to do it, delete `font-style: italic;` line from `article blockquote > cite` on the same file.
