### PR TITLE
Fix hovered title link colors for external url

### DIFF
--- a/sass/partials/_blog.scss
+++ b/sass/partials/_blog.scss
@@ -15,7 +15,7 @@ article {
       margin: 0;
       font-weight: 400;
       a { text-decoration: none;
-        @include link-colors($text-color, $hover: inherit, $focus: inherit, $visited: $text-color, $active: inherit);
+        @include link-colors($text-color, $visited: $text-color);
         }
     }
     p {


### PR DESCRIPTION
`inherit` was causing title link color to be set to `$text-color` even if it's hovered.
This bug can be reproduced in Safari (Mac), Chrome (Mac), iOS Safari, iOS Chrome.
This commit fixes it in Safari (Mac) and Chrome (Mac). Not checked in iOS and Android.
