### PR TITLE
update readme, added rake install command for zshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install
 -------
     $ cd octopress
     $ git clone git://github.com/lucaslew/whitespace.git .themes/whitespace
-    $ rake install['whitespace']
+    $ rake install['whitespace'] # for zsh, use: rake install\['whitespace'\] 
     $ rake generate
 
 


### PR DESCRIPTION
shell throws the error "zsh: no matches found: install[whitespace]" when you just type the command rake install['whitespace']

To make it work, the command needs to be tweaked to rake install['whitespace']

So I added it just so that people using zshell don't run into this error.
