### PR TITLE
Simplify code using `googleplus_user` as author

### DIFF
--- a/source/_includes/post/author.html
+++ b/source/_includes/post/author.html
@@ -9,15 +9,15 @@
   {% assign googleplus_user = post.googleplus_user | downcase %}
 {% elsif page.googleplus_user %}
   {% assign googleplus_user = page.googleplus_user | downcase %}
-{% else %}
+{% elsif site.googleplus_user %}
   {% assign googleplus_user = site.googleplus_user | downcase %}
 {% endif %}
 {% if author %}
   <span class="byline author vcard">Authored by <span class="fn">
-  {% if googleplus_user == "" or googleplus_user == nil or googleplus_user == "ignore" %}
-    {{ author }}
-  {% else %}
+  {% if googleplus_user and googleplus_user != "ignore" %}
     <a href="https://plus.google.com/{{ googleplus_user }}" rel="author">{{ author }}</a>
+  {% else %}
+    {{ author }}
   {% endif %}
   </span></span>
 {% endif %}


### PR DESCRIPTION
`{% else %}` makes `googleplus_user` not empty even if `site.googleplus_user` is empty. We have to check with `{% elsif site.googleplus_user %}`.
