### PR TITLE
Prevent scrollbar from repositioning page

### DIFF
--- a/sass/base/_theme.scss
+++ b/sass/base/_theme.scss
@@ -69,6 +69,7 @@ a {
 
 html {
   background: $page-bg;
+  overflow-y: scroll;
 }
 body {
   > div {


### PR DESCRIPTION
I am not sure if this is the best place to put this change, but this prevents page to be "shifted" when scrollbar appears in browser window.

https://stackoverflow.com/questions/1417934/how-to-prevent-scrollbar-from-repositioning-web-page
