### PR TITLE
Break words of inline code if it is necessary

### DIFF
--- a/sass/partials/_syntax.scss
+++ b/sass/partials/_syntax.scss
@@ -98,8 +98,8 @@ h3.filename {
 p, li {
   code {
     @extend .mono;
-    display: inline-block;
-    white-space: no-wrap;
+    display: inline;
+    word-wrap: break-word;
     background: #fff;
     font-size: .8em;
     line-height: 1.5em;


### PR DESCRIPTION
Very long inline code can't be seen on small screen now. We have to break the words if it's necessary.
