### PR TITLE
Adds Sass styles for tables

### DIFF
--- a/sass/_partials.scss
+++ b/sass/_partials.scss
@@ -5,3 +5,4 @@
 @import "partials/syntax";
 @import "partials/archive";
 @import "partials/footer";
+@import "partials/tables";

--- a/sass/partials/_tables.scss
+++ b/sass/partials/_tables.scss
@@ -1,0 +1,21 @@
+:not(.highlight) > table {
+  margin: 0 auto 1.5em auto;
+
+  tr {
+    background-color: #fff;
+    border-top: 1px solid #ccc;
+
+    th, td {
+      padding: 6px 13px;
+      border: 1px solid #ddd;
+    }
+
+    th {
+      font-weight: bold;
+    }
+  }
+
+  tr:nth-child(2n) {
+    background-color: #f8f8f8;
+  }
+}


### PR DESCRIPTION
Octopress can handle tables, but by default they have no style.
This commit adds GitHub-like style for tables.

Fixes #78